### PR TITLE
Fix mistakes in notebook 4

### DIFF
--- a/book/Course files/Notebook 4/Notebook 4 Scientific Computing.ipynb
+++ b/book/Course files/Notebook 4/Notebook 4 Scientific Computing.ipynb
@@ -218,7 +218,7 @@
     }
    },
    "source": [
-    "**WRONG!** Why? Because the makers of Python decided to start counting from zero: the first element of a tuple `a` is actually `a[0]`. \n",
+    "**WRONG!** Why? Because the makers of Python decided to start counting from zero: the first element of a sequence `a` is actually `a[0]`. \n",
     "\n",
     "(This is a long-standing <a href=https://en.wikipedia.org/wiki/Zero-based_numbering>discussion among computer scientists</a>, and the convention is <a href=https://en.wikipedia.org/wiki/Comparison_of_programming_languages_(array)#Array_dimensions>different</a> in many different languages. There are advantages and disadvantages of both, and even essays written about it...but in any case, Python chose to start arrays at zero.)\n",
     "\n",
@@ -395,11 +395,11 @@
    "source": [
     "###  Slicing numpy arrays<a class=\"anchor\" id=\"sub_section_4_1_2\"></a>\n",
     "\n",
-    "Numpy arrays also support a special type of indexing called \"slicing\" that does not just return a single element of an array, but instead returns a whole part of array. \n",
+    "Python sequences, inclduing NumPy arrays, also support a special type of indexing called \"slicing\" that does not just return a single element of an array, but instead returns a whole part of array. \n",
     "\n",
     "To do this, I put not just a single number inside my square brackets, but instead two numbers, separated by a colon `:`\n",
     "\n",
-    "`a[n:m]` will return a new tuple that consist of all the elements in `a`, starting at element `n` and ending at element `m-1`. \n",
+    "`a[n:m]` will return a view that consist of all the elements in `a`, starting at element `n` and ending at element `m-1`. \n",
     "\n",
     "Let's look at a concrete example:"
    ]


### PR DESCRIPTION
In notebook 4, which is about NumPy Arrays, tuples are mentioned some times when NumPy arrays are really meant. 